### PR TITLE
support irregular hexagon unit-steps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 .idea
+*.swp

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hexgridspiral"
-version = "0.2.8"
+version = "0.2.9"
 edition = "2021"
 include = [
     "**/*.rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hexgridspiral"
-version = "0.2.9"
+version = "0.3.0"
 edition = "2021"
 include = [
     "**/*.rs",

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 # Changelog
 Best-Effort (Means: worst-effort, actually).
 
-## v0.2.9
+## v0.3.0
 * Add `to_irregular_pixel` and `from_irregular_pixel` functions to `CCTile`: [pr1](https://github.com/lucidBrot/hexgridspiral/pull/1)
 
 ## v0.2.8

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,9 @@
 # Changelog
 Best-Effort (Means: worst-effort, actually).
 
+## v0.2.9
+* Add `to_irregular_pixel` and `from_irregular_pixel` functions to `CCTile`: [pr1](https://github.com/lucidBrot/hexgridspiral/pull/1)
+
 ## v0.2.8
 * Add `serde` dependency and implement `Serialize` and `Deserialize` on most types.
 

--- a/examples/spiral/main.rs
+++ b/examples/spiral/main.rs
@@ -12,7 +12,9 @@ fn main() {
     // Let's spawn twenty hex-tiles around the origin
     let step_size = 1.;
     for i in 0..21 {
-        let tile = HGSTile::make(i).cc().to_pixel((0., 0.), (step_size, step_size));
+        let tile = HGSTile::make(i)
+            .cc()
+            .to_pixel((0., 0.), (step_size, step_size));
         // Let's say you want to add tiles to your levelmap in the game UI:
         add_tile_to_user_interface(tile, i);
     }

--- a/examples/spiral/main.rs
+++ b/examples/spiral/main.rs
@@ -14,7 +14,8 @@ fn main() {
     for i in 0..21 {
         let tile = HGSTile::make(i)
             .cc()
-            .to_pixel((0., 0.), (step_size, step_size));
+            .to_pixel((0., 0.), step_size);
+            // You could also use .to_irregular_pixel for squished grids.
         // Let's say you want to add tiles to your levelmap in the game UI:
         add_tile_to_user_interface(tile, i);
     }

--- a/examples/spiral/main.rs
+++ b/examples/spiral/main.rs
@@ -12,7 +12,7 @@ fn main() {
     // Let's spawn twenty hex-tiles around the origin
     let step_size = 1.;
     for i in 0..21 {
-        let tile = HGSTile::make(i).cc().to_pixel((0., 0.), step_size.into());
+        let tile = HGSTile::make(i).cc().to_pixel((0., 0.), (step_size, step_size));
         // Let's say you want to add tiles to your levelmap in the game UI:
         add_tile_to_user_interface(tile, i);
     }

--- a/examples/spiral/main.rs
+++ b/examples/spiral/main.rs
@@ -12,10 +12,8 @@ fn main() {
     // Let's spawn twenty hex-tiles around the origin
     let step_size = 1.;
     for i in 0..21 {
-        let tile = HGSTile::make(i)
-            .cc()
-            .to_pixel((0., 0.), step_size);
-            // You could also use .to_irregular_pixel for squished grids.
+        let tile = HGSTile::make(i).cc().to_pixel((0., 0.), step_size);
+        // You could also use .to_irregular_pixel for squished grids.
         // Let's say you want to add tiles to your levelmap in the game UI:
         add_tile_to_user_interface(tile, i);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -990,13 +990,24 @@ impl CCTile {
 
     /// computes the coordinates in the plane as floats.
     /// * `unit_step` : The size of one step from a hex tile's center to its neighboring tile's center.
+    /// The `unit_step` is twice the incircle radius of the hex. Or `sqrt(3) * outcircle_radius`.
+    /// * `origin` : The pixel position of the origin-tile's center.
+    ///
+    /// The resulting pixel coordinates are in a system where positive x corresponds to [RingCornerIndex::RIGHT] and
+    /// positive y corresponds to the UP-direction between ([RingCornerIndex::TOPLEFT] and [RingCornerIndex::TOPRIGHT]).
+    pub fn to_pixel(&self, origin: (f64, f64), unit_step: f64) -> (f64, f64) {
+        self.to_irregular_pixel(origin, (unit_step, unit_step))
+    }
+
+    /// computes the coordinates in the plane as floats.
+    /// * `unit_step` : The size of one step from a hex tile's center to its neighboring tile's center.
     /// The `unit_step` is normally twice the incircle radius of the hex. Or `sqrt(3) * outcircle_radius`,
     /// but we allow the user to specify x and y steps separately to support irregular hexagons.
     /// * `origin` : The pixel position of the origin-tile's center.
     ///
     /// The resulting pixel coordinates are in a system where positive x corresponds to [RingCornerIndex::RIGHT] and
-    /// positive y corresponds to the UP-direction between ([RingCornerIndex::TOPLEFT] and [RingCornerIndex::TOPRIGHT])..
-    pub fn to_pixel(&self, origin: (f64, f64), unit_step: (f64, f64)) -> (f64, f64) {
+    /// positive y corresponds to the UP-direction between ([RingCornerIndex::TOPLEFT] and [RingCornerIndex::TOPRIGHT]).
+    pub fn to_irregular_pixel(&self, origin: (f64, f64), unit_step: (f64, f64)) -> (f64, f64) {
         // We have point-top hexes. Call the hex inner-radius iR and the hex outer-radius oR.
         // The width (aka iR) of a hex equals sqrt(3)/2 * height (aka oR).
         // On the redblobgames website, they call the "size" what I'd call oR.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,11 +20,26 @@ Read the [README](https://github.com/lucidBrot/hexgridspiral) for
 use derive_more::with_trait::Sub;
 use derive_more::{Add, Display, From, Into, Mul, Neg};
 use num_enum::{IntoPrimitive, TryFromPrimitive};
+use serde::{Deserialize, Serialize};
 use std::ops;
-use serde::{Serialize, Deserialize};
 
 #[derive(
-    Debug, Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Add, Sub, Mul, Display, From, Into, Hash, Serialize, Deserialize
+    Debug,
+    Copy,
+    Clone,
+    PartialOrd,
+    Ord,
+    PartialEq,
+    Eq,
+    Add,
+    Sub,
+    Mul,
+    Display,
+    From,
+    Into,
+    Hash,
+    Serialize,
+    Deserialize,
 )]
 pub struct TileIndex(pub u64);
 
@@ -180,7 +195,22 @@ pub struct HGSTile {
 /// Towards the right, `r` stays constant and is *positive* on the bottom side.
 /// Towards the top-right, `s` stays constant and is negative on the bottom side.
 // TODO: Division is not implemented for CCTile. If needed, it should yield a CCTileFloat type.
-#[derive(Debug, Copy, Clone, PartialEq, Display, From, Into, Eq, Neg, Add, Mul, Sub, Serialize, Deserialize)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Display,
+    From,
+    Into,
+    Eq,
+    Neg,
+    Add,
+    Mul,
+    Sub,
+    Serialize,
+    Deserialize,
+)]
 #[display("CCTile: ({q}, {r},{s})")]
 pub struct CCTile {
     q: i64,
@@ -1767,11 +1797,35 @@ mod test {
 
         // Test with a tile where both q and r are relevant, and origin and unit step are non-default.
         let tile35 = HGSTile::make(35).cc();
-        let pixel35 = tile35.to_pixel((2., 3.), (4.,4.));
+        let pixel35 = tile35.to_pixel((2., 3.), (4., 4.));
         // Tile 35, aka (3, 1, -4), is 2.5 steps to the right and one step down.
         let pxstep = CCTile::pixel_step_vertical(4.);
         let should_be_pixel_35 = (2. + 2.5 * pxstep.0, 3. - pxstep.1);
         assert_eq!(pixel35, should_be_pixel_35);
+    }
+
+    #[test]
+    fn test_conversion_to_pixel_pr1() {
+        // This test exists because I thought this looks wrong and was surprised the tests were
+        // passing:
+        // https://github.com/lucidBrot/hexgridspiral/pull/1/files#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L979L978
+        // Did they forget the division by sqrt(3) ?
+        // No. The code is correct, just misnamed.
+
+        let double_step_up_tile = HGSTile::make(9);
+        // The coordinates of tile 9 should be x = 0
+        // and y equals (1 side + 2 * circumradius).
+        let side = 1.;
+        let circumradius = side;
+        let inradius = f64::sqrt(3.) / 2. * circumradius;
+        let expected_x = 0.;
+        let expected_y = side + 2. * circumradius;
+        let unit_step = 2. * inradius;
+        let pixel = double_step_up_tile
+            .cc()
+            .to_pixel((0., 0.), (unit_step, unit_step));
+        assert_approx_eq!(pixel.0, expected_x);
+        assert_approx_eq!(pixel.1, expected_y);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -960,12 +960,13 @@ impl CCTile {
 
     /// computes the coordinates in the plane as floats.
     /// * `unit_step` : The size of one step from a hex tile's center to its neighboring tile's center.
-    /// The `unit_step` is twice the incircle radius of the hex. Or `sqrt(3) * outcircle_radius`.
+    /// The `unit_step` is normally twice the incircle radius of the hex. Or `sqrt(3) * outcircle_radius`,
+    /// but we allow the user to specify x and y steps separately to support irregular hexagons.
     /// * `origin` : The pixel position of the origin-tile's center.
     ///
     /// The resulting pixel coordinates are in a system where positive x corresponds to [RingCornerIndex::RIGHT] and
     /// positive y corresponds to the UP-direction between ([RingCornerIndex::TOPLEFT] and [RingCornerIndex::TOPRIGHT])..
-    pub fn to_pixel(&self, origin: (f64, f64), unit_step: f64) -> (f64, f64) {
+    pub fn to_pixel(&self, origin: (f64, f64), unit_step: (f64, f64)) -> (f64, f64) {
         // We have point-top hexes. Call the hex inner-radius iR and the hex outer-radius oR.
         // The width (aka iR) of a hex equals sqrt(3)/2 * height (aka oR).
         // On the redblobgames website, they call the "size" what I'd call oR.
@@ -975,8 +976,8 @@ impl CCTile {
         // oR is the outer radius of the hex circumcircle; or the edge length.
         // The unit_step is two times the height of a equilateral triangle, so
         // unit_step = sqrt(3.)/2*oR*2
-        let outer_radius = unit_step / f64::sqrt(3.);
-        let _redblob_size = outer_radius;
+        let _redblob_size_x = unit_step.0;
+        let _redblob_size_y = unit_step.1;
         // Walk both unit vectors.
         // Math according to https://www.redblobgames.com/grids/hexagons/#hex-to-pixel-axial
         // the unit vectors are, relative to the hex-edge length,
@@ -988,7 +989,7 @@ impl CCTile {
         // One step of incrementing q is one step along the x-axis.
         // But moving along the x-axis does not change r ... why does it contribute here?
         // Because it matters: One step of incrementing r, given a fixed q. That is also half a step along the x axis.
-        let x = unit_step * ((self.q as f64) + (self.r as f64) / 2.);
+        let x = _redblob_size_x * ((self.q as f64) + (self.r as f64) / 2.);
 
         // Expressing the basis vectors in terms of unit_step:
         // One step of incrementing q given a fixed r is half a step along the y axis.
@@ -1000,7 +1001,7 @@ impl CCTile {
         // Or, because this is in a equilateral triangle,
         // the dy is the height thereof, so sqrt(3.)/2 * unit_step.
         // mine2:
-        let y = f64::sqrt(3.) / 2. * unit_step * (-self.r as f64);
+        let y = f64::sqrt(3.) / 2. * _redblob_size_y * (-self.r as f64);
 
         // redblob: Equivalent to my "mine2" formula, because `redblob_size * sqrt(3) = unit_step`:
         // Unit_step is twice the height of the equilateral triangle spanned by two oR and an edge.
@@ -1730,24 +1731,32 @@ mod test {
         {
             let tile1_cc = CCTile::make(1);
             assert_eq!(tile1_cc, CCTile::from_qr(1, -1));
-            let tile1_px = tile1_cc.to_pixel((0., 0.), 1.);
+            let tile1_px = tile1_cc.to_pixel((0., 0.), (1., 1.));
             assert_eq!(tile1_px, (0.5, f64::sqrt(3.) / 2.));
         }
 
+        // Same test for differing unit_step
+        {
+            let tile1_cc = CCTile::make(1);
+            assert_eq!(tile1_cc, CCTile::from_qr(1, -1));
+            let tile1_px = tile1_cc.to_pixel((0., 0.), (1., 0.75));
+            assert_eq!(tile1_px, (0.5, 0.75 * f64::sqrt(3.) / 2.));
+        }
+
         let tile1_cc = CCTile::unit(&RingCornerIndex::RIGHT);
-        let tile1_px = tile1_cc.to_pixel((0., 0.), 1.);
+        let tile1_px = tile1_cc.to_pixel((0., 0.), (1., 1.));
         assert_eq!(tile1_px, (1., 0.));
 
         let tile_right = tile1_cc * 5;
-        assert_eq!(tile_right.to_pixel((1., 2.), 1.), (6., 2.));
+        assert_eq!(tile_right.to_pixel((1., 2.), (1., 1.)), (6., 2.));
 
         // Same at larger scale:
-        assert_eq!(tile1_cc.to_pixel((0., 0.), 10000.), (10000., 0.));
+        assert_eq!(tile1_cc.to_pixel((0., 0.), (10000., 10000.)), (10000., 0.));
 
         // Same with a tile that is not at r == 0:
         let tile2 = CCTile::unit(&RingCornerIndex::TOPLEFT);
         assert_eq!(tile2, CCTile::from_qr(0, -1));
-        let tile2_px = tile2.to_pixel((0., 0.), 1.);
+        let tile2_px = tile2.to_pixel((0., 0.), (1., 1.));
         let inner_radius = 0.5;
         let outer_radius = 2. / f64::sqrt(3.) * inner_radius;
         let y_should = 1.5 * outer_radius;
@@ -1758,7 +1767,7 @@ mod test {
 
         // Test with a tile where both q and r are relevant, and origin and unit step are non-default.
         let tile35 = HGSTile::make(35).cc();
-        let pixel35 = tile35.to_pixel((2., 3.), 4.);
+        let pixel35 = tile35.to_pixel((2., 3.), (4.,4.));
         // Tile 35, aka (3, 1, -4), is 2.5 steps to the right and one step down.
         let pxstep = CCTile::pixel_step_vertical(4.);
         let should_be_pixel_35 = (2. + 2.5 * pxstep.0, 3. - pxstep.1);
@@ -1776,7 +1785,7 @@ mod test {
             let tile = CCTile::new(h);
             let expected_pixel_x = unit_step * 1.5;
             let expected_pixel_y = unit_step * f64::sqrt(3.) / 2.;
-            let pixel = tile.to_pixel(origin, unit_step);
+            let pixel = tile.to_pixel(origin, (unit_step, unit_step));
             assert_approx_eq!(pixel.0, expected_pixel_x);
             assert_approx_eq!(pixel.1, expected_pixel_y);
             let tile2 = CCTile::from_pixel(pixel);
@@ -1792,7 +1801,7 @@ mod test {
         // Origin should be at (0,0)
         {
             let tile = CCTile::make(0);
-            assert_eq!(tile.to_pixel(origin, unit_step), (0., 0.));
+            assert_eq!(tile.to_pixel(origin, (unit_step, unit_step)), (0., 0.));
             assert_eq!(CCTile::from_pixel((0., 0.)), tile);
         }
 
@@ -1813,7 +1822,7 @@ mod test {
         {
             let tile = CCTile::make(1);
             assert_eq!(tile, CCTile::from_qr(1, -1));
-            let pixel = tile.to_pixel(origin, unit_step);
+            let pixel = tile.to_pixel(origin, (unit_step, unit_step));
             assert_approx_eq!(pixel.0, 0.5);
             assert_approx_eq!(pixel.1, f64::sqrt(3.) / 2. * unit_step);
         }
@@ -1828,7 +1837,7 @@ mod test {
         // Test that to and from pixel are consistent.
         for h in [0, 1, 2, 4, 5, 6, 8, 10, 27, 100] {
             let tile = CCTile::make(h);
-            let pixel = tile.to_pixel(origin, unit_step);
+            let pixel = tile.to_pixel(origin, (unit_step, unit_step));
             let tile2 = CCTile::from_pixel(pixel);
             assert_eq!(tile, tile2);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1077,6 +1077,10 @@ impl CCTile {
         Self::round_to_nearest_tile(q, r)
     }
 
+    pub fn from_irregular_pixel(pixel: (f64, f64), origin: (f64, f64), unit_steps: (f64, f64)) -> Self {
+        todo!("implement!")
+    }
+
     // https://www.redblobgames.com/grids/hexagons/#rounding
     pub fn round_to_nearest_tile(frac_q: f64, frac_r: f64) -> Self {
         // infer s from the sum-to-zero constraint
@@ -1772,32 +1776,34 @@ mod test {
         {
             let tile1_cc = CCTile::make(1);
             assert_eq!(tile1_cc, CCTile::from_qr(1, -1));
-            let tile1_px = tile1_cc.to_pixel((0., 0.), (1., 1.));
+            let tile1_px = tile1_cc.to_pixel((0., 0.), 1.);
             assert_eq!(tile1_px, (0.5, f64::sqrt(3.) / 2.));
+            let tile1_px_again = tile1_cc.to_irregular_pixel((0., 0.), (1., 1.));
+            assert_eq!(tile1_px, tile1_px_again);
         }
 
-        // Same test for differing unit_step
+        // Same test for differing unit_step in x and y
         {
             let tile1_cc = CCTile::make(1);
             assert_eq!(tile1_cc, CCTile::from_qr(1, -1));
-            let tile1_px = tile1_cc.to_pixel((0., 0.), (1., 0.75));
+            let tile1_px = tile1_cc.to_irregular_pixel((0., 0.), (1., 0.75));
             assert_eq!(tile1_px, (0.5, 0.75 * f64::sqrt(3.) / 2.));
         }
 
         let tile1_cc = CCTile::unit(&RingCornerIndex::RIGHT);
-        let tile1_px = tile1_cc.to_pixel((0., 0.), (1., 1.));
+        let tile1_px = tile1_cc.to_pixel((0., 0.), 1.);
         assert_eq!(tile1_px, (1., 0.));
 
         let tile_right = tile1_cc * 5;
-        assert_eq!(tile_right.to_pixel((1., 2.), (1., 1.)), (6., 2.));
+        assert_eq!(tile_right.to_pixel((1., 2.), 1.), (6., 2.));
 
         // Same at larger scale:
-        assert_eq!(tile1_cc.to_pixel((0., 0.), (10000., 10000.)), (10000., 0.));
+        assert_eq!(tile1_cc.to_irregular_pixel((0., 0.), (10000., 10000.)), (10000., 0.));
 
         // Same with a tile that is not at r == 0:
         let tile2 = CCTile::unit(&RingCornerIndex::TOPLEFT);
         assert_eq!(tile2, CCTile::from_qr(0, -1));
-        let tile2_px = tile2.to_pixel((0., 0.), (1., 1.));
+        let tile2_px = tile2.to_pixel((0., 0.), 1.);
         let inner_radius = 0.5;
         let outer_radius = 2. / f64::sqrt(3.) * inner_radius;
         let y_should = 1.5 * outer_radius;
@@ -1808,7 +1814,7 @@ mod test {
 
         // Test with a tile where both q and r are relevant, and origin and unit step are non-default.
         let tile35 = HGSTile::make(35).cc();
-        let pixel35 = tile35.to_pixel((2., 3.), (4., 4.));
+        let pixel35 = tile35.to_pixel((2., 3.), 4.);
         // Tile 35, aka (3, 1, -4), is 2.5 steps to the right and one step down.
         let pxstep = CCTile::pixel_step_vertical(4.);
         let should_be_pixel_35 = (2. + 2.5 * pxstep.0, 3. - pxstep.1);
@@ -1834,7 +1840,7 @@ mod test {
         let unit_step = 2. * inradius;
         let pixel = double_step_up_tile
             .cc()
-            .to_pixel((0., 0.), (unit_step, unit_step));
+            .to_pixel((0., 0.), unit_step);
         assert_approx_eq!(pixel.0, expected_x);
         assert_approx_eq!(pixel.1, expected_y);
     }
@@ -1850,7 +1856,7 @@ mod test {
             let tile = CCTile::new(h);
             let expected_pixel_x = unit_step * 1.5;
             let expected_pixel_y = unit_step * f64::sqrt(3.) / 2.;
-            let pixel = tile.to_pixel(origin, (unit_step, unit_step));
+            let pixel = tile.to_pixel(origin, unit_step);
             assert_approx_eq!(pixel.0, expected_pixel_x);
             assert_approx_eq!(pixel.1, expected_pixel_y);
             let tile2 = CCTile::from_pixel(pixel);
@@ -1866,7 +1872,7 @@ mod test {
         // Origin should be at (0,0)
         {
             let tile = CCTile::make(0);
-            assert_eq!(tile.to_pixel(origin, (unit_step, unit_step)), (0., 0.));
+            assert_eq!(tile.to_pixel(origin, unit_step), (0., 0.));
             assert_eq!(CCTile::from_pixel((0., 0.)), tile);
         }
 
@@ -1887,7 +1893,7 @@ mod test {
         {
             let tile = CCTile::make(1);
             assert_eq!(tile, CCTile::from_qr(1, -1));
-            let pixel = tile.to_pixel(origin, (unit_step, unit_step));
+            let pixel = tile.to_pixel(origin, unit_step);
             assert_approx_eq!(pixel.0, 0.5);
             assert_approx_eq!(pixel.1, f64::sqrt(3.) / 2. * unit_step);
         }
@@ -1902,8 +1908,22 @@ mod test {
         // Test that to and from pixel are consistent.
         for h in [0, 1, 2, 4, 5, 6, 8, 10, 27, 100] {
             let tile = CCTile::make(h);
-            let pixel = tile.to_pixel(origin, (unit_step, unit_step));
+            let pixel = tile.to_pixel(origin, unit_step);
             let tile2 = CCTile::from_pixel(pixel);
+            assert_eq!(tile, tile2);
+        }
+    }
+
+    #[test]
+    fn test_conversion_from_irregular_pixel_and_back() {
+        let origin = (0., 0.);
+        let unit_step_x= 2.;
+        let unit_step_y= 3.5;
+        // Test that to and from pixel are consistent.
+        for h in [0, 1, 2, 4, 5, 6, 8, 10, 27, 100] {
+            let tile = CCTile::make(h);
+            let pixel = tile.to_irregular_pixel(origin, (unit_step_x, unit_step_y));
+            let tile2 = CCTile::from_irregular_pixel(pixel, origin, (unit_step_x, unit_step_y));
             assert_eq!(tile, tile2);
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1067,18 +1067,20 @@ impl CCTile {
 
     /// Inversion of the formula in [CCTile::to_pixel] and rounding to the nearest hex tile.
     /// `unit_step` determines the scaling - it is the distance between two adjacent hex tile centers, in pixel units.
+    /// For use on irregular grids, see [Self::from_irregular_pixel].
     pub fn from_pixel_(pixel: (f64, f64), origin: (f64, f64), unit_step: f64) -> Self {
-        let x = pixel.0 - origin.0;
-        let y = pixel.1 - origin.1;
-        // Based on to_pixel formulas:
-        // let x = unit_step * ((self.q as f64) + (self.r as f64) / 2.);
-        // let y = f64::sqrt(3.)/2.*unit_step*(-self.r as f64);
-        let r = -2. / f64::sqrt(3.) * y / unit_step;
-        let q = x / unit_step - (r / 2.);
-        Self::round_to_nearest_tile(q, r)
+        Self::from_irregular_pixel(pixel, origin, (unit_step, unit_step))
     }
 
-    pub fn from_irregular_pixel(pixel: (f64, f64), origin: (f64, f64), unit_steps: (f64, f64)) -> Self {
+    /// Inversion of the formula in [CCTile::to_pixel] and rounding to the nearest hex tile.
+    /// `unit_steps` determines the scaling - it is the distance between two adjacent hex tile centers, in pixel units.
+    /// For an irregular grid (of hex tile centers), you can specify a tuple `(unit_step_x,
+    /// unit_step_y)`.
+    pub fn from_irregular_pixel(
+        pixel: (f64, f64),
+        origin: (f64, f64),
+        unit_steps: (f64, f64),
+    ) -> Self {
         let x = pixel.0 - origin.0;
         let y = pixel.1 - origin.1;
         // Based on to_pixel formulas:
@@ -1806,7 +1808,10 @@ mod test {
         assert_eq!(tile_right.to_pixel((1., 2.), 1.), (6., 2.));
 
         // Same at larger scale:
-        assert_eq!(tile1_cc.to_irregular_pixel((0., 0.), (10000., 10000.)), (10000., 0.));
+        assert_eq!(
+            tile1_cc.to_irregular_pixel((0., 0.), (10000., 10000.)),
+            (10000., 0.)
+        );
 
         // Same with a tile that is not at r == 0:
         let tile2 = CCTile::unit(&RingCornerIndex::TOPLEFT);
@@ -1846,9 +1851,7 @@ mod test {
         let expected_x = 0.;
         let expected_y = side + 2. * circumradius;
         let unit_step = 2. * inradius;
-        let pixel = double_step_up_tile
-            .cc()
-            .to_pixel((0., 0.), unit_step);
+        let pixel = double_step_up_tile.cc().to_pixel((0., 0.), unit_step);
         assert_approx_eq!(pixel.0, expected_x);
         assert_approx_eq!(pixel.1, expected_y);
     }
@@ -1925,8 +1928,8 @@ mod test {
     #[test]
     fn test_conversion_from_irregular_pixel_and_back() {
         let origin = (0., 0.);
-        let unit_step_x= 2.;
-        let unit_step_y= 3.5;
+        let unit_step_x = 2.;
+        let unit_step_y = 3.5;
         // Test that to and from pixel are consistent.
         for h in [0, 1, 2, 4, 5, 6, 8, 10, 27, 100] {
             let tile = CCTile::make(h);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1007,18 +1007,19 @@ impl CCTile {
     ///
     /// The resulting pixel coordinates are in a system where positive x corresponds to [RingCornerIndex::RIGHT] and
     /// positive y corresponds to the UP-direction between ([RingCornerIndex::TOPLEFT] and [RingCornerIndex::TOPRIGHT]).
-    pub fn to_irregular_pixel(&self, origin: (f64, f64), unit_step: (f64, f64)) -> (f64, f64) {
+    pub fn to_irregular_pixel(&self, origin: (f64, f64), unit_steps: (f64, f64)) -> (f64, f64) {
         // We have point-top hexes. Call the hex inner-radius iR and the hex outer-radius oR.
         // The width (aka iR) of a hex equals sqrt(3)/2 * height (aka oR).
         // On the redblobgames website, they call the "size" what I'd call oR.
+        //   ==> ( redblob_size = outer_radius = unit_step / sqrt(3) )
         // On the x-axis, two centers are exactly 2*iR away.
         // On the y-axis, they are not on the same x-coord, so it's different.
         // There they are 3/4 * oR away from each other.
         // oR is the outer radius of the hex circumcircle; or the edge length.
         // The unit_step is two times the height of a equilateral triangle, so
         // unit_step = sqrt(3.)/2*oR*2
-        let _redblob_size_x = unit_step.0;
-        let _redblob_size_y = unit_step.1;
+        let unit_step_x = unit_steps.0;
+        let unit_step_y = unit_steps.1;
         // Walk both unit vectors.
         // Math according to https://www.redblobgames.com/grids/hexagons/#hex-to-pixel-axial
         // the unit vectors are, relative to the hex-edge length,
@@ -1030,7 +1031,7 @@ impl CCTile {
         // One step of incrementing q is one step along the x-axis.
         // But moving along the x-axis does not change r ... why does it contribute here?
         // Because it matters: One step of incrementing r, given a fixed q. That is also half a step along the x axis.
-        let x = _redblob_size_x * ((self.q as f64) + (self.r as f64) / 2.);
+        let x = unit_step_x * ((self.q as f64) + (self.r as f64) / 2.);
 
         // Expressing the basis vectors in terms of unit_step:
         // One step of incrementing q given a fixed r is half a step along the y axis.
@@ -1042,7 +1043,7 @@ impl CCTile {
         // Or, because this is in a equilateral triangle,
         // the dy is the height thereof, so sqrt(3.)/2 * unit_step.
         // mine2:
-        let y = f64::sqrt(3.) / 2. * _redblob_size_y * (-self.r as f64);
+        let y = f64::sqrt(3.) / 2. * unit_step_y * (-self.r as f64);
 
         // redblob: Equivalent to my "mine2" formula, because `redblob_size * sqrt(3) = unit_step`:
         // Unit_step is twice the height of the equilateral triangle spanned by two oR and an edge.
@@ -1078,7 +1079,14 @@ impl CCTile {
     }
 
     pub fn from_irregular_pixel(pixel: (f64, f64), origin: (f64, f64), unit_steps: (f64, f64)) -> Self {
-        todo!("implement!")
+        let x = pixel.0 - origin.0;
+        let y = pixel.1 - origin.1;
+        // Based on to_pixel formulas:
+        // let x = unit_step_x * ((self.q as f64) + (self.r as f64) / 2.);
+        // let y = f64::sqrt(3.)/2.*unit_step_y*(-self.r as f64);
+        let r = -2. / f64::sqrt(3.) * y / unit_steps.1;
+        let q = x / unit_steps.0 - (r / 2.);
+        Self::round_to_nearest_tile(q, r)
     }
 
     // https://www.redblobgames.com/grids/hexagons/#rounding


### PR DESCRIPTION
 useful for rectangular sprite renderings that aren't always regular hexagon shapes.